### PR TITLE
Fix for Bug #82 - missing linebreak in tweetview

### DIFF
--- a/res/values-v11/style.xml
+++ b/res/values-v11/style.xml
@@ -22,7 +22,7 @@
         <item name="android:background">#446644</item>
     </style>
 
-    <style name="ZwitscherStyle" parent="android:Theme">
+    <style name="ZwitscherStyle" parent="android:style/Theme.Holo">
         <item name="android:actionBarStyle">@style/MyActionBar</item>
         <item name="android:actionBarSplitStyle">@style/MyActionBar</item>
         <item name="android:actionBarTabBarStyle">@style/MyActionBar</item>


### PR DESCRIPTION
Could reproduce the line break problem on my defy running cyanogenmod 7.2.0 as well. It seems that the problem is theme related (for example [http://stackoverflow.com/questions/11583261/textview-wont-break-text](http://stackoverflow.com/questions/11583261/textview-wont-break-text)). Running the app without any custom style shows the desired line breaks. Introducing a version dependent style definition fixes the problem for me. I checked on my defy and on the emulator running a 4.0.2 flavour. Both worked fine for me.
Kind regards Michael
